### PR TITLE
add POST /channel endpoint for opening channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,34 @@
-```
+# MutinyNet Faucet API
+
+1. Copy `.env.sample` to `.env.local` and fill it out with bitcoind and lnd connection info
+2. Run `cargo build && cargo start`
+
+## Endpoint examples
+
+```sh
 curl -X POST \
   http://localhost:3001/api/onchain \
   -H 'Content-Type: application/json' \
   -d '{"sats":10000,"address":"bcrt1..."}'
 ```
 
-```
+```sh
 curl -X POST \
   http://localhost:3001/api/lightning \
   -H 'Content-Type: application/json' \
   -d '{"bolt11": "..."}'
 ```
 
-```
+```sh
 curl -X POST \
   http://localhost:3001/api/bolt11 \
   -H 'Content-Type: application/json' \
   -d '{"amount_sats": 1234}'
+```
+
+```sh
+curl -X POST \
+  http://localhost:3001/api/channel \
+  -H 'Content-Type: application/json' \
+  -d '{"capacity": 2468,"push_amount": 1234,"pubkey":"023...","host":"127.0.0.1:9735"}'
 ```

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+
+use std::sync::{Arc, Mutex};
+use tonic_openssl_lnd::lnrpc::{self, channel_point};
+
+use crate::{AppState, MAX_SEND_AMOUNT};
+
+#[derive(Clone, Deserialize)]
+pub struct ChannelRequest {
+    capacity: i64,
+    push_amount: i64,
+    pubkey: String,
+    host: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct ChannelResponse {
+    pub txid: String,
+}
+
+pub async fn open_channel(
+    state: Arc<Mutex<AppState>>,
+    payload: ChannelRequest,
+) -> anyhow::Result<String> {
+    if payload.capacity > MAX_SEND_AMOUNT.try_into().unwrap() {
+        anyhow::bail!("max capacity is 1,000,000");
+    }
+    if payload.push_amount < 0 {
+        anyhow::bail!("push_amount must be positive");
+    }
+    if payload.push_amount > payload.capacity {
+        anyhow::bail!("push_amount must be less than or equal to capacity");
+    }
+
+    println!("pubkey: {:?}", payload.pubkey);
+    println!("capacity: {:?}", payload.capacity);
+    println!("push_amount: {:?}", payload.push_amount);
+
+    let node_pubkey_result = hex::decode(payload.pubkey.clone());
+    let node_pubkey = match node_pubkey_result {
+        Ok(pubkey) => pubkey,
+        Err(e) => anyhow::bail!("invalid pubkey: {}", e),
+    };
+
+    let channel_point = {
+        let mut lightning_client = state
+            .clone()
+            .lock()
+            .map_err(|_| anyhow::anyhow!("failed to get lock"))?
+            .lightning_client
+            .clone();
+
+        lightning_client
+            .connect_peer(lnrpc::ConnectPeerRequest {
+                addr: Some(lnrpc::LightningAddress {
+                    pubkey: payload.pubkey.clone(),
+                    host: payload.host,
+                }),
+                ..Default::default()
+            })
+            .await
+            .ok();
+
+        lightning_client
+            .open_channel_sync(lnrpc::OpenChannelRequest {
+                node_pubkey,
+                local_funding_amount: payload.capacity,
+                push_sat: payload.push_amount,
+                ..Default::default()
+            })
+            .await?
+            .into_inner()
+    };
+
+    println!("channel_point: {:?}", channel_point);
+
+    let txid = match &channel_point.funding_txid {
+        Some(channel_point::FundingTxid::FundingTxidBytes(bytes)) => hex::encode(bytes.clone()),
+        Some(channel_point::FundingTxid::FundingTxidStr(string)) => string.clone(),
+        None => anyhow::bail!("failed to open channel"),
+    };
+
+    Ok(txid)
+}

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -23,7 +23,7 @@ pub async fn open_channel(
     payload: ChannelRequest,
 ) -> anyhow::Result<String> {
     if payload.capacity > MAX_SEND_AMOUNT.try_into().unwrap() {
-        anyhow::bail!("max capacity is 1,000,000");
+        anyhow::bail!("max capacity is 10,000,000");
     }
     if payload.push_amount < 0 {
         anyhow::bail!("push_amount must be positive");

--- a/src/onchain.rs
+++ b/src/onchain.rs
@@ -24,7 +24,7 @@ pub async fn pay_onchain(
     payload: OnchainRequest,
 ) -> anyhow::Result<String> {
     if payload.sats > MAX_SEND_AMOUNT {
-        anyhow::bail!("max amount is 1,000,000");
+        anyhow::bail!("max amount is 10,000,000");
     }
 
     let txid = {


### PR DESCRIPTION
### What This Does

Adds a `POST /api/channel` endpoint for opening new channels, and pushing some amount to allow for quickly creating channels with a preferred balance, since a common use-case of the faucet is to get a utxo, then open a channel from your lightning node. Also added a little bit more to the README for getting started.

I'm a trash rust dev so this PR is in draft because A) I'm sure that the code in `src/channel.rs` could be better and B) I don't think I'm properly deriving the `txid` from `channel_point` and I'm too stupid to figure out how to do it correctly. If anyone could help get it in a better state, I'd really appreciate it.

This will be accompanied by a PR in https://github.com/MutinyWallet/mutinynet-faucet with a UI.