### PR TITLE
Add L402 Lightning payment authentication

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,7 +12,7 @@ export GITHUB_CLIENT_ID="my_github_client_id"
 export GITHUB_CLIENT_SECRET="my_github_client_secret"
 export HOST="localhost"
 
-# Mainnet LND for paid reorgs
+# Mainnet LND for paid reorgs and L402 auth
 export MAINNET_GRPC_HOST="127.0.0.1"
 export MAINNET_GRPC_PORT="10009"
 export MAINNET_TLS_CERT_PATH="path/to/mainnet/tls.cert"
@@ -22,3 +22,7 @@ export MAINNET_ADMIN_MACAROON_PATH="path/to/mainnet/admin.macaroon"
 export REORG_ENABLED="true"
 export REORG_COOLDOWN_SECONDS="3600"
 export REORG_DB_PATH="reorg.db"
+
+# L402 Lightning authentication
+export L402_ENABLED="true"
+export L402_INVOICE_AMOUNT="1000"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     name: Rust Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,10 +1,9 @@
+use crate::l402::{validate_l402_credentials, L402Error};
 use crate::AppState;
-use axum::headers::authorization::Bearer;
-use axum::headers::Authorization;
-use axum::http::{Request, StatusCode};
+use axum::http::{HeaderMap, Request, StatusCode};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use axum::{Json, TypedHeader};
+use axum::Json;
 use jsonwebtoken::{decode, DecodingKey, Validation};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -144,43 +143,72 @@ pub struct AuthUser {
     pub username: String,
 }
 
-// Middleware for JWT verification
+// Middleware for JWT and L402 verification
 pub async fn auth_middleware<B>(
-    TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
+    headers: HeaderMap,
     mut request: Request<B>,
     next: Next<B>,
 ) -> Result<Response, AuthError> {
     let state = request
         .extensions()
         .get::<AppState>()
-        .expect("JWT config not found in extensions");
+        .expect("AppState not found in extensions");
 
-    if auth.token().is_empty() {
-        return Err(AuthError::MissingToken);
-    }
+    let auth_header = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .ok_or(AuthError::MissingToken)?;
 
-    // Verify and decode the token
-    let token_data = decode::<TokenClaims>(
-        auth.token(),
-        &DecodingKey::from_secret(state.auth.jwt_secret.as_bytes()),
-        &Validation::default(),
-    )
-    .map_err(|_| AuthError::InvalidToken)?;
+    let auth_user = if let Some(token) = auth_header.strip_prefix("Bearer ") {
+        // GitHub OAuth JWT path
+        if token.is_empty() {
+            return Err(AuthError::MissingToken);
+        }
 
-    // Check if token is expired
-    let now = chrono::Utc::now().timestamp() as usize;
-    if token_data.claims.exp < now {
-        return Err(AuthError::TokenExpired);
-    }
+        let token_data = decode::<TokenClaims>(
+            token,
+            &DecodingKey::from_secret(state.auth.jwt_secret.as_bytes()),
+            &Validation::default(),
+        )
+        .map_err(|_| AuthError::InvalidToken)?;
 
-    if is_banned(&token_data.claims.sub) {
-        return Err(AuthError::TokenExpired);
-    }
+        let now = chrono::Utc::now().timestamp() as usize;
+        if token_data.claims.exp < now {
+            return Err(AuthError::TokenExpired);
+        }
 
-    // Add AuthUser to request extensions
-    request.extensions_mut().insert(AuthUser {
-        username: token_data.claims.sub,
-    });
+        if is_banned(&token_data.claims.sub) {
+            return Err(AuthError::TokenExpired);
+        }
 
+        AuthUser {
+            username: token_data.claims.sub,
+        }
+    } else if let Some(credentials) = auth_header.strip_prefix("L402 ") {
+        // L402 Lightning payment path
+        let (token, preimage_hex) = credentials
+            .split_once(':')
+            .ok_or(AuthError::InvalidToken)?;
+
+        if token.is_empty() || preimage_hex.is_empty() {
+            return Err(AuthError::MissingToken);
+        }
+
+        let payment_hash =
+            validate_l402_credentials(token, preimage_hex, &state.auth.jwt_secret).map_err(
+                |e| match e {
+                    L402Error::TokenExpired => AuthError::TokenExpired,
+                    _ => AuthError::InvalidToken,
+                },
+            )?;
+
+        AuthUser {
+            username: format!("l402:{}", payment_hash),
+        }
+    } else {
+        return Err(AuthError::InvalidToken);
+    };
+
+    request.extensions_mut().insert(auth_user);
     Ok(next.run(request).await)
 }

--- a/src/l402.rs
+++ b/src/l402.rs
@@ -1,0 +1,220 @@
+use anyhow::Result;
+use bitcoin::hashes::hex::FromHex;
+use bitcoin::hashes::{sha256, Hash};
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use tonic_openssl_lnd::lnrpc;
+use tonic_openssl_lnd::LndLightningClient;
+
+#[derive(Clone)]
+pub struct L402Config {
+    pub enabled: bool,
+    pub invoice_amount_sats: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct L402Claims {
+    pub payment_hash: String,
+    pub exp: usize,
+    pub iat: usize,
+}
+
+pub struct L402TokenResponse {
+    pub invoice: String,
+    pub token: String,
+}
+
+pub async fn generate_l402_token(
+    mainnet_client: &LndLightningClient,
+    jwt_secret: &str,
+    amount_sats: u64,
+) -> Result<L402TokenResponse> {
+    let inv = lnrpc::Invoice {
+        memo: "Mutinynet Faucet L402 Auth".to_string(),
+        value: amount_sats as i64,
+        expiry: 600, // 10 minutes
+        ..Default::default()
+    };
+
+    let response = mainnet_client.clone().add_invoice(inv).await?.into_inner();
+    let payment_hash = sha256::Hash::from_slice(&response.r_hash)
+        .map_err(|e| anyhow::anyhow!("Invalid payment hash from LND: {}", e))?
+        .to_string();
+
+    let now = chrono::Utc::now().timestamp() as usize;
+    let claims = L402Claims {
+        payment_hash,
+        exp: (chrono::Utc::now() + chrono::Duration::hours(24)).timestamp() as usize,
+        iat: now,
+    };
+
+    let token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(jwt_secret.as_bytes()),
+    )?;
+
+    Ok(L402TokenResponse {
+        invoice: response.payment_request,
+        token,
+    })
+}
+
+pub fn verify_l402_preimage(preimage_hex: &str, payment_hash_hex: &str) -> bool {
+    let preimage_bytes = match Vec::<u8>::from_hex(preimage_hex) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+
+    let expected = match sha256::Hash::from_str(payment_hash_hex) {
+        Ok(h) => h,
+        Err(_) => return false,
+    };
+
+    sha256::Hash::hash(&preimage_bytes) == expected
+}
+
+#[derive(Debug, PartialEq)]
+pub enum L402Error {
+    InvalidToken,
+    TokenExpired,
+    InvalidPreimage,
+}
+
+/// Validates L402 credentials: decodes the JWT, checks expiry, and verifies the preimage.
+/// Returns the payment_hash on success.
+pub fn validate_l402_credentials(
+    token: &str,
+    preimage_hex: &str,
+    jwt_secret: &str,
+) -> Result<String, L402Error> {
+    let token_data = decode::<L402Claims>(
+        token,
+        &DecodingKey::from_secret(jwt_secret.as_bytes()),
+        &Validation::default(),
+    )
+    .map_err(|e| match e.kind() {
+        jsonwebtoken::errors::ErrorKind::ExpiredSignature => L402Error::TokenExpired,
+        _ => L402Error::InvalidToken,
+    })?;
+
+    if !verify_l402_preimage(preimage_hex, &token_data.claims.payment_hash) {
+        return Err(L402Error::InvalidPreimage);
+    }
+
+    Ok(token_data.claims.payment_hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_SECRET: &str = "test_secret";
+    const TEST_PREIMAGE: &str =
+        "0000000000000000000000000000000000000000000000000000000000000001";
+
+    fn test_payment_hash() -> String {
+        let preimage_bytes = Vec::<u8>::from_hex(TEST_PREIMAGE).unwrap();
+        sha256::Hash::hash(&preimage_bytes).to_string()
+    }
+
+    fn make_test_token(payment_hash: &str, secret: &str, exp_offset_hours: i64) -> String {
+        let now = chrono::Utc::now().timestamp() as usize;
+        let claims = L402Claims {
+            payment_hash: payment_hash.to_string(),
+            exp: (chrono::Utc::now() + chrono::Duration::hours(exp_offset_hours)).timestamp()
+                as usize,
+            iat: now,
+        };
+        encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .unwrap()
+    }
+
+    // -- verify_l402_preimage tests --
+
+    #[test]
+    fn test_verify_preimage_valid() {
+        assert!(verify_l402_preimage(TEST_PREIMAGE, &test_payment_hash()));
+    }
+
+    #[test]
+    fn test_verify_preimage_wrong_hash() {
+        let wrong_hash = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert!(!verify_l402_preimage(TEST_PREIMAGE, wrong_hash));
+    }
+
+    #[test]
+    fn test_verify_preimage_bad_hex() {
+        assert!(!verify_l402_preimage("not_hex", "also_not_hex"));
+    }
+
+    // -- validate_l402_credentials tests --
+
+    #[test]
+    fn test_validate_valid_credentials() {
+        let payment_hash = test_payment_hash();
+        let token = make_test_token(&payment_hash, TEST_SECRET, 24);
+
+        let result = validate_l402_credentials(&token, TEST_PREIMAGE, TEST_SECRET);
+        assert_eq!(result, Ok(payment_hash));
+    }
+
+    #[test]
+    fn test_validate_wrong_preimage() {
+        let payment_hash = test_payment_hash();
+        let token = make_test_token(&payment_hash, TEST_SECRET, 24);
+
+        let wrong_preimage =
+            "0000000000000000000000000000000000000000000000000000000000000002";
+        let result = validate_l402_credentials(&token, wrong_preimage, TEST_SECRET);
+        assert_eq!(result, Err(L402Error::InvalidPreimage));
+    }
+
+    #[test]
+    fn test_validate_expired_token() {
+        let payment_hash = test_payment_hash();
+        let token = make_test_token(&payment_hash, TEST_SECRET, -1);
+
+        let result = validate_l402_credentials(&token, TEST_PREIMAGE, TEST_SECRET);
+        assert_eq!(result, Err(L402Error::TokenExpired));
+    }
+
+    #[test]
+    fn test_validate_wrong_secret() {
+        let payment_hash = test_payment_hash();
+        let token = make_test_token(&payment_hash, "secret_a", 24);
+
+        let result = validate_l402_credentials(&token, TEST_PREIMAGE, "secret_b");
+        assert_eq!(result, Err(L402Error::InvalidToken));
+    }
+
+    #[test]
+    fn test_validate_garbage_token() {
+        let result = validate_l402_credentials("not.a.jwt", TEST_PREIMAGE, TEST_SECRET);
+        assert_eq!(result, Err(L402Error::InvalidToken));
+    }
+
+    #[test]
+    fn test_validate_github_jwt_rejected() {
+        // A GitHub-style JWT (has `sub`, no `payment_hash`) must not decode as L402Claims
+        let github_claims = serde_json::json!({
+            "sub": "user@example.com",
+            "exp": 9999999999u64,
+            "iat": 1000000000u64,
+        });
+        let token = encode(
+            &Header::default(),
+            &github_claims,
+            &EncodingKey::from_secret(TEST_SECRET.as_bytes()),
+        )
+        .unwrap();
+
+        let result = validate_l402_credentials(&token, TEST_PREIMAGE, TEST_SECRET);
+        assert_eq!(result, Err(L402Error::InvalidToken));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ use bolt11::{request_bolt11, Bolt11Request, Bolt11Response};
 use channel::{open_channel, ChannelRequest, ChannelResponse};
 use lightning::{pay_lightning, LightningRequest, LightningResponse};
 use onchain::{pay_onchain, OnchainRequest, OnchainResponse};
+use l402::{generate_l402_token, L402Config};
 use reorg::{
     generate_reorg_invoice, start_reorg_invoice_listener, ReorgInvoiceRequest, ReorgInvoiceResponse,
 };
@@ -42,6 +43,7 @@ use setup::setup;
 mod auth;
 mod bolt11;
 mod channel;
+mod l402;
 mod lightning;
 mod nostr_dms;
 mod onchain;
@@ -62,6 +64,7 @@ pub struct AppState {
     payments: PaymentsByIp,
     auth: AuthState,
     reorg_config: ReorgConfig,
+    l402_config: L402Config,
 }
 
 #[derive(Clone)]
@@ -83,6 +86,7 @@ impl AppState {
         network: bitcoin::Network,
         auth: AuthState,
         reorg_config: ReorgConfig,
+        l402_config: L402Config,
     ) -> Self {
         let lnurl = lnurl::Builder::default().build_async().unwrap();
         AppState {
@@ -97,6 +101,7 @@ impl AppState {
             payments: PaymentsByIp::new(),
             auth,
             reorg_config,
+            l402_config,
         }
     }
 }
@@ -126,6 +131,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/api/lnurlw", get(lnurlw_handler))
         .route("/api/lnurlw/callback", get(lnurlw_callback_handler))
         .route("/api/bolt11", post(bolt11_handler))
+        .route("/api/l402", post(l402_handler))
         .route(
             "/api/channel",
             post(channel_handler).route_layer(middleware::from_fn(auth_middleware)),
@@ -471,6 +477,38 @@ async fn lnurlw_callback_handler(
     } else {
         Err(Json(json!({"status": "ERROR", "reason": "Incorrect k1"})))
     }
+}
+
+#[derive(Serialize)]
+struct L402HandlerResponse {
+    invoice: String,
+    token: String,
+}
+
+#[axum::debug_handler]
+async fn l402_handler(
+    Extension(state): Extension<AppState>,
+) -> Result<Json<L402HandlerResponse>, AppError> {
+    if !state.l402_config.enabled {
+        return Err(AppError::new("L402 authentication is not enabled"));
+    }
+
+    let mainnet_client = state
+        .mainnet_lightning_client
+        .as_ref()
+        .ok_or_else(|| AppError::new("Mainnet LND not configured"))?;
+
+    let response = generate_l402_token(
+        mainnet_client,
+        &state.auth.jwt_secret,
+        state.l402_config.invoice_amount_sats,
+    )
+    .await?;
+
+    Ok(Json(L402HandlerResponse {
+        invoice: response.invoice,
+        token: response.token,
+    }))
 }
 
 #[axum::debug_handler]

--- a/src/payments.rs
+++ b/src/payments.rs
@@ -72,7 +72,7 @@ impl PaymentsByIp {
             self.add_payment_impl(&address.to_string(), amount).await;
         }
         if let Some(user) = user {
-            self.add_payment_impl(format!("github:{}", user.username).as_str(), amount)
+            self.add_payment_impl(format!("user:{}", user.username).as_str(), amount)
                 .await;
         }
     }
@@ -115,7 +115,7 @@ impl PaymentsByIp {
             }
         };
         if let Some(user) = user {
-            if let Some(tracker) = trackers.get_mut(format!("github:{}", user.username).as_str()) {
+            if let Some(tracker) = trackers.get_mut(format!("user:{}", user.username).as_str()) {
                 user_amt += tracker.sum_payments();
             }
         }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -8,6 +8,7 @@ use nostr::key::Keys;
 use tonic_openssl_lnd::lnrpc;
 
 use crate::auth::AuthState;
+use crate::l402::L402Config;
 use crate::reorg::init_reorg_db;
 use crate::{AppState, ReorgConfig};
 
@@ -96,8 +97,18 @@ pub async fn setup() -> anyhow::Result<AppState> {
         .unwrap_or_else(|_| "3600".to_string())
         .parse::<u64>()?;
 
-    // Initialize mainnet LND client if reorg is enabled
-    let mainnet_lightning_client = if reorg_enabled {
+    // Initialize L402 configuration
+    let l402_enabled = env::var("L402_ENABLED")
+        .unwrap_or_else(|_| "false".to_string())
+        .parse::<bool>()?;
+
+    let l402_invoice_amount_sats = env::var("L402_INVOICE_AMOUNT")
+        .unwrap_or_else(|_| "1000".to_string())
+        .parse::<u64>()?;
+
+    // Initialize mainnet LND client if reorg or L402 is enabled
+    let needs_mainnet_lnd = reorg_enabled || l402_enabled;
+    let mainnet_lightning_client = if needs_mainnet_lnd {
         let mainnet_address = env::var("MAINNET_GRPC_HOST").ok();
         let mainnet_macaroon = env::var("MAINNET_ADMIN_MACAROON_PATH").ok();
         let mainnet_cert = env::var("MAINNET_TLS_CERT_PATH").ok();
@@ -148,7 +159,7 @@ pub async fn setup() -> anyhow::Result<AppState> {
                 Some(mainnet_client)
             }
             _ => {
-                warn!("REORG_ENABLED=true but mainnet LND env vars not set. Reorg feature will be disabled.");
+                warn!("Mainnet LND env vars not set. Features requiring mainnet LND will be disabled.");
                 None
             }
         }
@@ -237,6 +248,23 @@ pub async fn setup() -> anyhow::Result<AppState> {
         pricing,
     };
 
+    // Finalize L402 config
+    let l402_final_enabled = l402_enabled && mainnet_lightning_client.is_some();
+
+    if l402_enabled && !l402_final_enabled {
+        warn!("L402 feature requested but mainnet LND not configured. L402 disabled.");
+    } else if l402_final_enabled {
+        info!(
+            "L402 authentication enabled with {} sat invoice amount",
+            l402_invoice_amount_sats
+        );
+    }
+
+    let l402_config = L402Config {
+        enabled: l402_final_enabled,
+        invoice_amount_sats: l402_invoice_amount_sats,
+    };
+
     Ok(AppState::new(
         host,
         keys,
@@ -247,5 +275,6 @@ pub async fn setup() -> anyhow::Result<AppState> {
         network,
         auth,
         reorg_config,
+        l402_config,
     ))
 }


### PR DESCRIPTION
## Summary
- Adds L402 as an alternative to GitHub OAuth for accessing protected faucet endpoints
- Users pay a small mainnet Lightning invoice (`POST /api/l402`) to get a token, then authenticate with `Authorization: L402 <token>:<preimage>`
- Pure cryptographic verification — no database or background task needed, just JWT decode + sha256(preimage) == payment_hash
- Configurable via `L402_ENABLED` and `L402_INVOICE_AMOUNT` env vars, requires mainnet LND

## Changes
- **`src/l402.rs`** (new): L402 config, JWT claims, token generation, preimage verification, credential validation + 9 unit tests
- **`src/auth.rs`**: Refactored `auth_middleware` from `TypedHeader<Bearer>` to manual `HeaderMap` parsing, supports both `Bearer` and `L402` auth schemes
- **`src/main.rs`**: Added `POST /api/l402` endpoint (unauthenticated), `L402Config` in `AppState`
- **`src/setup.rs`**: Decoupled mainnet LND init from reorg feature, loads L402 env vars
- **`src/payments.rs`**: Changed rate limit prefix from `github:` to `user:` for multi-auth support

## Deployment
- Set `L402_ENABLED=true` and `L402_INVOICE_AMOUNT=<sats>` (default 1000)
- Requires mainnet LND env vars (`MAINNET_GRPC_HOST`, etc.) — same ones used by the reorg feature

## Test plan
- [x] `cargo build` — clean, no warnings
- [x] `cargo test` — 9 tests pass (preimage verification, credential validation, expiry, wrong secret, cross-auth rejection)
- [ ] Manual: `POST /api/l402` returns `{ invoice, token }` with mainnet LND connected
- [ ] Manual: Pay invoice, use `Authorization: L402 <token>:<preimage>` on `/api/onchain`
- [ ] Manual: Verify existing GitHub OAuth flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)