### PR TITLE
Add POST /api/arkade forwarding to an internal Arkade dispenser daemon

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -30,3 +30,9 @@ export L402_INVOICE_AMOUNT="1000"
 # Analytics database
 export ANALYTICS_DB_PATH="analytics.db"
 export ANALYTICS_TOKEN="my_analytics_secret"
+
+# Arkade dispenser daemon (internal network)
+# Leave unset to disable POST /api/arkade.
+export ARKADE_DAEMON_URL="http://arkade-daemon:8080"
+# Optional shared secret sent as X-Internal-Token to the daemon.
+# export ARKADE_INTERNAL_TOKEN="my_shared_secret"

--- a/src/arkade.rs
+++ b/src/arkade.rs
@@ -1,0 +1,81 @@
+use log::info;
+use serde::{Deserialize, Serialize};
+
+use crate::auth::AuthUser;
+use crate::{AppState, MAX_SEND_AMOUNT};
+
+#[derive(Clone, Deserialize)]
+pub struct ArkadeRequest {
+    pub address: String,
+    pub sats: u64,
+}
+
+#[derive(Clone, Serialize)]
+pub struct ArkadeResponse {
+    pub txid: String,
+}
+
+pub async fn dispense_arkade(
+    state: &AppState,
+    x_forwarded_for: &str,
+    user: &AuthUser,
+    payload: ArkadeRequest,
+) -> anyhow::Result<ArkadeResponse> {
+    let daemon_url = state
+        .arkade_daemon_url
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("Arkade daemon not configured"))?;
+
+    if payload.sats == 0 {
+        anyhow::bail!("sats must be positive");
+    }
+    if payload.sats > MAX_SEND_AMOUNT {
+        anyhow::bail!("max amount is 1,000,000");
+    }
+
+    state
+        .payments
+        .add_payment(x_forwarded_for, None, Some(user), payload.sats)
+        .await;
+
+    let daemon_url = daemon_url.trim_end_matches('/');
+    let mut req = reqwest::Client::new()
+        .post(format!("{daemon_url}/send"))
+        .json(&serde_json::json!({ "address": payload.address, "sats": payload.sats }));
+
+    if let Some(token) = state.arkade_internal_token.as_deref() {
+        req = req.header("X-Internal-Token", token);
+    }
+
+    let resp = req.send().await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("arkade daemon returned {status}: {body}");
+    }
+
+    let json: serde_json::Value = resp.json().await?;
+    let txid = json
+        .get("txid")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("arkade daemon returned no txid"))?
+        .to_string();
+
+    info!(
+        "arkade dispensed {} sats to {} for gh:{}",
+        payload.sats, payload.address, user.username
+    );
+
+    if let Some(tx) = &state.analytics_writer {
+        crate::analytics::record_payment(
+            tx,
+            "arkade",
+            payload.sats,
+            Some(&user.username),
+            x_forwarded_for,
+            Some(&payload.address),
+        );
+    }
+
+    Ok(ArkadeResponse { txid })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ use crate::analytics::{
     analytics_balance, analytics_combined, analytics_domains, analytics_l402, analytics_recent,
     analytics_summary, analytics_timeseries, analytics_users, user_recent,
 };
+use crate::arkade::{dispense_arkade, ArkadeRequest, ArkadeResponse};
 use crate::auth::{auth_middleware, AuthState, AuthUser, GithubCallback, UsersCache};
 use crate::nostr_dms::listen_to_nostr_dms;
 use crate::payments::PaymentsByIp;
@@ -48,6 +49,7 @@ use setup::setup;
 
 mod admin;
 mod analytics;
+mod arkade;
 mod auth;
 mod bolt11;
 mod channel;
@@ -85,6 +87,11 @@ pub struct AppState {
     pub analytics_writer: Option<mpsc::UnboundedSender<analytics::AnalyticsPayment>>,
     /// API token for analytics endpoints
     pub analytics_token: Option<String>,
+    /// Base URL of the Arkade dispenser daemon on the internal network.
+    /// If unset, POST /api/arkade returns an error.
+    pub arkade_daemon_url: Option<String>,
+    /// Optional shared secret sent to the daemon as X-Internal-Token.
+    pub arkade_internal_token: Option<String>,
 }
 
 #[derive(Clone)]
@@ -113,6 +120,8 @@ impl AppState {
         analytics_db: Option<SqlitePool>,
         analytics_writer: Option<mpsc::UnboundedSender<analytics::AnalyticsPayment>>,
         analytics_token: Option<String>,
+        arkade_daemon_url: Option<String>,
+        arkade_internal_token: Option<String>,
     ) -> Self {
         let lnurl = lnurl::Builder::default().build_async().unwrap();
         AppState {
@@ -134,6 +143,8 @@ impl AppState {
             analytics_db,
             analytics_writer,
             analytics_token,
+            arkade_daemon_url,
+            arkade_internal_token,
         }
     }
 }
@@ -169,6 +180,10 @@ async fn main() -> anyhow::Result<()> {
         .route(
             "/api/channel",
             post(channel_handler).route_layer(middleware::from_fn(auth_middleware)),
+        )
+        .route(
+            "/api/arkade",
+            post(arkade_handler).route_layer(middleware::from_fn(auth_middleware)),
         )
         .route(
             "/api/reorg/invoice",
@@ -789,6 +804,31 @@ async fn limits_handler(
         is_premium: user.is_premium,
         window_seconds: 86_400,
     }))
+}
+
+#[axum::debug_handler]
+async fn arkade_handler(
+    Extension(state): Extension<AppState>,
+    Extension(user): Extension<AuthUser>,
+    headers: HeaderMap,
+    Json(payload): Json<ArkadeRequest>,
+) -> Result<Json<ArkadeResponse>, AppError> {
+    let x_forwarded_for = headers
+        .get("x-forwarded-for")
+        .and_then(|x| HeaderValue::to_str(x).ok())
+        .unwrap_or("Unknown");
+
+    if state
+        .payments
+        .verify_payments(x_forwarded_for, None, Some(&user))
+        .await
+        && !user.is_premium
+    {
+        return Err(AppError::new("Too many payments"));
+    }
+
+    let res = dispense_arkade(&state, x_forwarded_for, &user, payload).await?;
+    Ok(Json(res))
 }
 
 #[axum::debug_handler]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -304,6 +304,13 @@ pub async fn setup() -> anyhow::Result<AppState> {
         warn!("ANALYTICS_TOKEN not set — analytics endpoints will return 404");
     }
 
+    let arkade_daemon_url = env::var("ARKADE_DAEMON_URL").ok();
+    let arkade_internal_token = env::var("ARKADE_INTERNAL_TOKEN").ok();
+    match arkade_daemon_url.as_deref() {
+        Some(url) => info!("Arkade daemon configured at {}", url),
+        None => warn!("ARKADE_DAEMON_URL not set — /api/arkade will return an error"),
+    }
+
     Ok(AppState::new(
         host,
         keys,
@@ -321,5 +328,7 @@ pub async fn setup() -> anyhow::Result<AppState> {
         analytics_db,
         analytics_writer,
         analytics_token,
+        arkade_daemon_url,
+        arkade_internal_token,
     ))
 }


### PR DESCRIPTION
This adds a `POST /api/arkade` route so logged-in users can dispense mutinynet funds to a `tark1…` Arkade address, alongside the existing on-chain and Lightning endpoints. It's the backend half of MutinyWallet/mutinynet-faucet#18 — the frontend gained a "Send to Arkade" tab that expects this route.

The actual Arkade wallet doesn't live here. It runs as a small standalone daemon on the internal Docker network (image `ghcr.io/kukks/arkade-faucet-daemon`, source at [Kukks/arkade-faucet-daemon](https://github.com/Kukks/arkade-faucet-daemon)) with a `POST /send` that takes `{address, sats}` and returns `{txid}`. This handler runs the same rate-limit / premium / auth checks the other paid endpoints use, then forwards the body to `${ARKADE_DAEMON_URL}/send` and passes the daemon's response back to the caller.

Auth is done here so the daemon has no user-facing auth surface — that's the whole shape. If you'd rather the daemon do its own auth (e.g. re-verify against `/auth/check`), that's easy to unwind on the daemon side; the current thin proxy is what avoids putting the faucet credential on a second origin the browser talks to.

The endpoint is opt-in per deployment: leave `ARKADE_DAEMON_URL` unset and the route returns an error. `ARKADE_INTERNAL_TOKEN` is an optional shared secret forwarded to the daemon as `X-Internal-Token` for defense in depth on shared internal networks; also opt-in.

The compose side (`arkade-daemon` service, env wiring) is proposed in a companion PR against `mutiny-net` — will link once it's up. `cargo check` passes against `rust:1.85.0` matching the repo's `Dockerfile`. Nothing else in the codebase moves; analytics records dispenses as `payment_type="arkade"`.

Happy to rename the endpoint, the env vars, or the analytics label if you'd rather they match a different convention.